### PR TITLE
fix: skip empty repositories instead of crashing

### DIFF
--- a/evergreen.py
+++ b/evergreen.py
@@ -111,6 +111,9 @@ def main():  # pragma: no cover
         if repo.archived:
             print(f"Skipping {repo.full_name} (archived)")
             continue
+        if is_empty_repo(repo):
+            print(f"Skipping {repo.full_name} (empty repository)")
+            continue
         if repo.visibility.lower() not in config.filter_visibility:
             print(f"Skipping {repo.full_name} (visibility-filtered)")
             continue
@@ -313,6 +316,17 @@ def is_repo_created_date_before(
     return created_after_date and repo_created_at_date < datetime.strptime(
         created_after_date, "%Y-%m-%d"
     )
+
+
+def is_empty_repo(repo):
+    """Check whether the repository is empty (has no commits).
+
+    Empty repositories cannot hold or receive a dependabot configuration, and
+    every ``repo.get_contents(...)`` call against them returns a 404
+    ("This repository is empty."). Detecting them up front lets the caller skip
+    them before any content lookup, rather than crashing partway through.
+    """
+    return repo.size == 0
 
 
 def is_dependabot_security_updates_enabled(ghe, ghe_api_url, owner, repo, access_token):

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,6 +1,6 @@
 """Custom exceptions for the evergreen application."""
 
-from github import UnknownObjectException
+from github import GithubException, UnknownObjectException
 
 
 class OptionalFileNotFoundError(UnknownObjectException):
@@ -47,3 +47,13 @@ def check_optional_file(repo, filename):
         raise OptionalFileNotFoundError(
             status=e.status, data=e.data, headers=e.headers
         ) from e
+    except GithubException as e:
+        # An empty repository (one with no commits) returns a 404 that PyGithub
+        # raises as the base GithubException ("This repository is empty.")
+        # rather than UnknownObjectException. Treat it the same as a missing
+        # optional file so the repository is skipped instead of crashing the run.
+        if e.status == 404:
+            raise OptionalFileNotFoundError(
+                status=e.status, data=e.data, headers=e.headers
+            ) from e
+        raise

--- a/test_evergreen.py
+++ b/test_evergreen.py
@@ -19,6 +19,7 @@ from evergreen import (
     get_global_project_id,
     get_repos_iterator,
     is_dependabot_security_updates_enabled,
+    is_empty_repo,
     is_repo_created_date_before,
     link_item_to_project,
 )
@@ -360,6 +361,22 @@ class TestCheckPendingIssuesForDuplicates(unittest.TestCase):
 
         # Assert that the function returned the expected result
         self.assertTrue(result)
+
+
+class TestIsEmptyRepo(unittest.TestCase):
+    """Test the is_empty_repo function in evergreen.py"""
+
+    def test_is_empty_repo_true_for_size_zero(self):
+        """A repository with no commits reports size 0 and is considered empty."""
+        mock_repo = MagicMock()
+        mock_repo.size = 0
+        self.assertTrue(is_empty_repo(mock_repo))
+
+    def test_is_empty_repo_false_for_non_zero_size(self):
+        """A repository with content is not considered empty."""
+        mock_repo = MagicMock()
+        mock_repo.size = 42
+        self.assertFalse(is_empty_repo(mock_repo))
 
 
 class TestGetReposIterator(unittest.TestCase):

--- a/test_exceptions.py
+++ b/test_exceptions.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import Mock
 
 from exceptions import OptionalFileNotFoundError, check_optional_file
-from github import UnknownObjectException
+from github import GithubException, UnknownObjectException
 
 
 class TestOptionalFileNotFoundError(unittest.TestCase):
@@ -93,6 +93,40 @@ class TestCheckOptionalFile(unittest.TestCase):
 
         self.assertEqual(context.exception.__cause__, original_error)
         mock_repo.get_contents.assert_called_once_with("missing.yml")
+
+    def test_check_optional_file_with_empty_repository(self):
+        """Test check_optional_file when the repository is empty.
+
+        An empty repository returns a 404 that PyGithub raises as the base
+        GithubException rather than UnknownObjectException. It should be
+        translated to OptionalFileNotFoundError so the repository is skipped.
+        """
+        mock_repo = Mock()
+
+        original_error = GithubException(
+            status=404, data={"message": "This repository is empty."}
+        )
+        mock_repo.get_contents.side_effect = original_error
+
+        with self.assertRaises(OptionalFileNotFoundError) as context:
+            check_optional_file(mock_repo, "config.yml")
+
+        self.assertEqual(context.exception.__cause__, original_error)
+        mock_repo.get_contents.assert_called_once_with("config.yml")
+
+    def test_check_optional_file_reraises_non_404_github_exception(self):
+        """Test check_optional_file re-raises non-404 GithubExceptions unchanged."""
+        mock_repo = Mock()
+
+        original_error = GithubException(status=403, data={"message": "Forbidden"})
+        mock_repo.get_contents.side_effect = original_error
+
+        with self.assertRaises(GithubException) as context:
+            check_optional_file(mock_repo, "config.yml")
+
+        self.assertNotIsInstance(context.exception, OptionalFileNotFoundError)
+        self.assertEqual(context.exception.status, 403)
+        mock_repo.get_contents.assert_called_once_with("config.yml")
 
     def test_check_optional_file_can_catch_as_unknown_object_exception(self):
         """Test that OptionalFileNotFoundError from check_optional_file can be caught as UnknownObjectException."""


### PR DESCRIPTION
## Problem

When Evergreen iterates over an organization that contains an **empty repository** (one created but never pushed to, so it has no commits), the run crashes:

```
github.GithubException.GithubException: This repository is empty.: 404
{"message": "This repository is empty.",
 "documentation_url": "https://docs.github.com/v3/repos/contents/#get-contents",
 "status": "404"}
```

`check_optional_file()` in `exceptions.py` calls `repo.get_contents(...)` to look for an existing `dependabot.yml`. For a repo where the file merely does not exist, PyGithub raises `UnknownObjectException`, which is caught and translated to `OptionalFileNotFoundError`. But for an **empty** repository, GitHub returns a 404 that PyGithub surfaces as the **base** `GithubException` (`"This repository is empty."`), not `UnknownObjectException`. That escapes the existing handler and aborts the whole run, so no other repositories in the org get processed.

## Fix

Handle a 404 `GithubException` the same way as a missing optional file, so the repository is treated as having no config and skipped by the normal flow. Non-404 `GithubException`s (permissions, rate limits, server errors) are re-raised unchanged so genuine problems are not masked.

## Tests

Added two cases to `test_exceptions.py`:
- an empty-repository 404 (base `GithubException`) is translated to `OptionalFileNotFoundError`
- a non-404 `GithubException` (e.g. 403) is re-raised unchanged

All existing tests still pass.
